### PR TITLE
fix: Remove calls to 7TV API

### DIFF
--- a/io/index.js
+++ b/io/index.js
@@ -83,20 +83,6 @@ export default function async() {
         };
         emotes.push(newEmoteObject);
       }
-      // 7TV
-      console.log("Fetching 7TV emotes...");
-      const sevenTvEmotes = await axios.get(
-        "https://api.7tv.app/v2/emotes/global"
-      );
-      // Format BTTV emotes
-      for await (const emote of sevenTvEmotes.data) {
-        const newEmoteObject = {
-          id: emote.id,
-          code: emote.name,
-          source: "7tv",
-        };
-        emotes.push(newEmoteObject);
-      }
     };
     await fetchEmotes();
 


### PR DESCRIPTION
Solves issue #65 by removing calls to the 7TV API. It fixes the problem and allows the server to run, but it's more bypassing the issue than solving it, so perhaps you'd prefer an alternative solution.